### PR TITLE
Remove obsolete site test for footer

### DIFF
--- a/services/site/tests/components/Footer.spec.tsx
+++ b/services/site/tests/components/Footer.spec.tsx
@@ -14,10 +14,4 @@ describe("footer", () => {
 
     expect(screen.getByLabelText("Footer")).toBeInTheDocument();
   });
-
-  it("renders a sponsor / social navigation inside the footer", () => {
-    render(<Footer />);
-
-    expect(screen.getByLabelText("Social Links and Sponsors")).toBeInTheDocument();
-  });
 });


### PR DESCRIPTION
Currently we have an obsolete test for the presence of the social nav, this PR removes that test.