### PR TITLE
Fix environment name in the destroy review app action

### DIFF
--- a/.github/workflows/destroy-review-app.yml
+++ b/.github/workflows/destroy-review-app.yml
@@ -1,7 +1,6 @@
 name: Destroy Review App
 
 on:
-  workflow_dispatch:
   pull_request:
     types:
       - closed
@@ -12,10 +11,9 @@ jobs:
     outputs:
       environment-name: ${{ steps.environment-name.outputs.environment-name }}
     steps:
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
-
-      - run: echo "environment-name=${{ env.GITHUB_REF_SLUG }}" >> $GITHUB_OUTPUT
+        # manually create the environment name since the inject slug action
+        # inserts develop into env.GITHUB_REF_SLUG
+      - run: echo "environment-name=${{ github.event.number }}-merge" >> $GITHUB_OUTPUT
         id: environment-name
 
   destroy-review-app:


### PR DESCRIPTION
Destroying review apps automatically currently does not work since the action for creating the environment name uses the current branch instead of the merge request closed event for creating the name.

Creating the name manually should fix this issue.