### PR TITLE
Fix ScrollOverlay

### DIFF
--- a/services/site/src/components/common/ScrollOverlayWrapper.tsx
+++ b/services/site/src/components/common/ScrollOverlayWrapper.tsx
@@ -36,7 +36,7 @@ const ScrollOverlayWrapper: React.FunctionComponent<ScrollOverlayWrapperProps> =
     const containerHeight = element.clientHeight;
     const scrollableHeight = element.scrollHeight;
     const scrollDistanceToTop = element.scrollTop;
-    const isScrolledToBottom = containerHeight === scrollableHeight - scrollDistanceToTop;
+    const isScrolledToBottom = Math.abs(scrollableHeight - (containerHeight + scrollDistanceToTop)) < 1;
 
     setShowBottomOverlay(!isScrolledToBottom);
     setShowTopOverlay(scrollDistanceToTop > 0);


### PR DESCRIPTION
The current error is caused by a 0.5 divergence in the height values provided by the browser

 
<img width="379" alt="Bildschirm­foto 2023-03-10 um 15 54 21" src="https://user-images.githubusercontent.com/13380047/224348852-edf9d32f-98b9-4a94-aed9-32b3486147c2.png">

My change makes the ScrollOverlay resistant to divergences smaller than 1.