### PR TITLE
Turn off react-hooks/exhaustive-deps

### DIFF
--- a/services/site/.eslintrc.json
+++ b/services/site/.eslintrc.json
@@ -16,7 +16,8 @@
     "es6": true
   },
   "rules": {
-    "jsx-a11y/anchor-is-valid": "off"
+    "jsx-a11y/anchor-is-valid": "off",
+    "react-hooks/exhaustive-deps": "off"
   },
   "ignorePatterns": ["src/generated/**", "**/node_modules"]
 }


### PR DESCRIPTION
Previously, react-hooks/exhaustive-deps was set to warning (per default) causing warnings in each PR. For example: 
<img width="968" alt="Bildschirm­foto 2023-03-10 um 16 51 15" src="https://user-images.githubusercontent.com/13380047/224362418-21499536-3808-4a0f-b465-c6fd53a74984.png">



Oftentimes, this rule is not wanted (e.g. a useEffect() with empty dependency array because it should only be executed on initial render). It is tedious to always disable the rule manually.