### PR TITLE
Fix 404 Page

### DIFF
--- a/services/site/src/components/icons/IllustrationLostSpace.tsx
+++ b/services/site/src/components/icons/IllustrationLostSpace.tsx
@@ -7,7 +7,7 @@ const IllustrationLostSpace: React.FunctionComponent<React.SVGProps<SVGSVGElemen
       data-testid="IllustrationLostSpace"
       data-name="Layer 1"
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 902.41854 826.20679"
+      viewBox="0 0 910 830"
       className={className}
       aria-hidden="true"
       focusable="false"

--- a/services/site/src/pages/404.tsx
+++ b/services/site/src/pages/404.tsx
@@ -1,6 +1,5 @@
 import ErrorWithIllustration from "app/components/ErrorWithIllustration";
 import Footer from "app/components/Footer";
-import FullScreenLayout from "app/components/layouts/FullScreenLayout";
 import Navigation from "app/components/Navigation";
 import clsx from "clsx";
 import Head from "next/head";
@@ -13,13 +12,13 @@ const Custom404: React.FunctionComponent = () => {
         <title>404 Page not found | a11yphant</title>
         <meta name="robots" content="noindex,nofollow" />
       </Head>
-      <FullScreenLayout header={<Navigation />} footer={<Footer />}>
-        <main className={clsx("h-full box-border max-w-screen-3xl mx-auto")}>
-          <div className={clsx("mx-8 py-8 h-main", "lg:mx-24")}>
-            <ErrorWithIllustration error="Error 404" text="seems like you got lost in space" />
-          </div>
-        </main>
-      </FullScreenLayout>
+      <Navigation />
+      <main className={clsx("h-full box-border max-w-screen-3xl mx-auto")}>
+        <div className={clsx("mx-8 py-8 h-main", "lg:mx-24")}>
+          <ErrorWithIllustration error="Error 404" text="seems like you got lost in space" />
+        </div>
+      </main>
+      <Footer />
     </>
   );
 };

--- a/services/site/src/pages/_error.tsx
+++ b/services/site/src/pages/_error.tsx
@@ -1,6 +1,5 @@
 import Footer from "app/components/Footer";
 import IllustrationLost from "app/components/icons/IllustrationLost";
-import FullScreenLayout from "app/components/layouts/FullScreenLayout";
 import Navigation from "app/components/Navigation";
 import clsx from "clsx";
 import { NextPage } from "next";
@@ -21,32 +20,32 @@ const CustomError: NextPage<CustomErrorProps> = ({ statusCode, hasGetInitialProp
         <title>Something went wrong | a11yphant</title>
         <meta name="robots" content="noindex,nofollow" />
       </Head>
-      <FullScreenLayout header={<Navigation />} footer={<Footer />}>
-        <main className={clsx("h-full box-border max-w-screen-3xl mx-auto")}>
-          <section
-            className={clsx("mx-8 py-8 h-full flex flex-col justify-center items-left", "md:flex-row md:items-center md:justify-between", "lg:mx-24")}
-          >
-            <div>
-              <h1 className={clsx("font-normal mb-4", "h5", "sm:h4")}>Error {statusCode}</h1>
-              <p className={clsx("text-3xl max-w-lg font-bold leading-tight", "md:text-4xl", "xl:text-6xl")}>ooops, something went wrong</p>
-              <Link href="/">
-                <a
-                  className={clsx(
-                    "w-max mt-8 px-6 py-2.5 font-normal bg-primary text-light border-primary border-2 rounded tracking-wider inline-flex items-center",
-                    "transition duration-300",
-                    "hover:text-light hover:bg-primary-dark hover:border-primary-dark",
-                  )}
-                >
-                  Go to homepage
-                </a>
-              </Link>
-            </div>
-            <IllustrationLost
-              className={clsx("max-w-xs mt-24 col-span-1 self-start", "md:mt-0 md:mx-8 md:self-center", "lg:max-w-xl", "2xl:max-w-4xl")}
-            />
-          </section>
-        </main>
-      </FullScreenLayout>
+      <Navigation />
+      <main className={clsx("h-full box-border max-w-screen-3xl mx-auto")}>
+        <section
+          className={clsx("mx-8 py-8 h-full flex flex-col justify-center items-left", "md:flex-row md:items-center md:justify-between", "lg:mx-24")}
+        >
+          <div>
+            <h1 className={clsx("font-normal mb-4", "h5", "sm:h4")}>Error {statusCode}</h1>
+            <p className={clsx("text-3xl max-w-lg font-bold leading-tight", "md:text-4xl", "xl:text-6xl")}>ooops, something went wrong</p>
+            <Link href="/">
+              <a
+                className={clsx(
+                  "w-max mt-8 px-6 py-2.5 font-normal bg-primary text-light border-primary border-2 rounded tracking-wider inline-flex items-center",
+                  "transition duration-300",
+                  "hover:text-light hover:bg-primary-dark hover:border-primary-dark",
+                )}
+              >
+                Go to homepage
+              </a>
+            </Link>
+          </div>
+          <IllustrationLost
+            className={clsx("max-w-xs mt-24 col-span-1 self-start", "md:mt-0 md:mx-8 md:self-center", "lg:max-w-xl", "2xl:max-w-4xl")}
+          />
+        </section>
+      </main>
+      <Footer />
     </>
   );
 };


### PR DESCRIPTION
- extend viewBox of IllustrationLostSpace to avoid cut off
- remove the FullScreenLayout from the 404 page because it doesn't work with the new footer (the footer is so tall that the main content is shrinked to 0)