### PR TITLE
Bugfix: Spacing around Challenge-Anchor on homepage

### DIFF
--- a/services/site/src/pages/index.tsx
+++ b/services/site/src/pages/index.tsx
@@ -94,7 +94,7 @@ const Home: React.VoidFunctionComponent<HomeProps> = ({ fmType }) => {
           {!currentUser?.isRegistered && <Hero />}
           <section
             id="challenges"
-            className={clsx("max-w-screen-3xl mx-8 mt-32 mb-4", "sm:mx-12 sm:mt-28 sm:mb-12", "md:mx-24 md:mb-24", "2xl:mx-auto")}
+            className={clsx("max-w-screen-3xl mx-8 pt-10 mt-22 mb-4", "sm:mx-12 sm:mt-18 sm:mb-12", "md:mx-24 md:mb-24", "2xl:mx-auto")}
           >
             <ChallengeHeader className={clsx("2xl:mx-24")} userLoggedIn={currentUser?.isRegistered} />
 


### PR DESCRIPTION
# Description

- adds padding while it removes some margin

**Please test if it works better now, as it worked before most of the time on my device.**

## Definition of Done

### General

- [x] Code Review
- [ ] Test Coverage is equal or higher
- [x] Update ticket on the TODO board
- [x] (if .env file changes) Notify other team members

### Site

- [ ] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)