### PR TITLE
Update color of a11phant in hero text

### DIFF
--- a/services/site/src/components/homepage/Hero.tsx
+++ b/services/site/src/components/homepage/Hero.tsx
@@ -23,8 +23,10 @@ const Hero: React.FC = () => {
         </h2>
         <p className={clsx("text-grey-middle text-lg max-w-[40ch]")}>
           <span className="sr-only">allyphant</span>
-          <span aria-hidden="true">a11yphant</span> teaches web accessibility, one step at a time, broken down into manageable pieces. We call these
-          challenges.
+          <span aria-hidden="true" className="text-grey-middle">
+            a11yphant
+          </span>{" "}
+          teaches web accessibility, one step at a time, broken down into manageable pieces. We call these challenges.
         </p>
         <Link href="/#challenges">
           <a


### PR DESCRIPTION
# Description

- fixes the color of a11yphant in the page hero

## Definition of Done

### General

- [ ] Code Review
- [x] Test Coverage is equal or higher
- [x] (if .env file changes) Notify other team members

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)