### PR TITLE
Make video play inline on iOS

### DIFF
--- a/services/site/src/pages/about.tsx
+++ b/services/site/src/pages/about.tsx
@@ -78,7 +78,7 @@ const About: React.FunctionComponent = () => {
                 }}
               />
             ) : (
-              <video autoPlay muted loop controls>
+              <video autoPlay muted loop playsInline controls>
                 <source src="/videos/a11yphant-showcase.mp4" />
                 <p>
                   Your browser doesn't support HTML video. Here is a <a href="/videos/a11yphant-showcase.mp4">link to the video</a> instead.


### PR DESCRIPTION
# Description

- Make the video on the about page play inline on iOS

Closes https://github.com/a11yphant/issues/issues/18

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher
- [x] Update ticket on the TODO board
- [x] (if .env file changes) Notify other team members

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)