### PR TITLE
Change the hero text back to the pre-CCA version

### DIFF
--- a/services/site/src/components/homepage/Hero.tsx
+++ b/services/site/src/components/homepage/Hero.tsx
@@ -18,15 +18,16 @@ const Hero: React.FC = () => {
         <h2
           className={clsx("mb-6 max-w-2xl font-bold font-sans text-3xl leading-tight", "sm:text-4xl sm:leading-snug", "xl:text-5xl xl:leading-snug")}
         >
-          Learn to code <br /> accessibly with <br /> <span className="sr-only">allyphant</span>
-          <span aria-hidden="true">a11yphant</span>.
+          Learning web accessibility made easy
         </h2>
-        <p className={clsx("text-grey-middle text-lg max-w-[36ch]")}>
+        <p className={clsx("text-grey-middle text-lg")}>
           <span className="sr-only">allyphant</span>
-          <span aria-hidden="true" className="text-grey-middle">
+          <span aria-hidden="true" className="text-inherit">
             a11yphant
           </span>{" "}
-          teaches web accessibility, one step at a time, broken down into manageable pieces. We call these challenges.
+          teaches web accessibility, one step at a time, broken down into manageable pieces. We call these challenges. You won't need to read large
+          amounts of text to complete those. Instead, you will learn by applying the concepts in code. Get started with your first web accessibility
+          challenge and improve your skills.
         </p>
         <Link
           href="/#challenges"


### PR DESCRIPTION
# Description

- change text back to pre-CCA version

Closes https://github.com/a11yphant/issues/issues/23

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher
- [x] Update ticket on the TODO board
- [x] (if .env file changes) Notify other team members

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)