### PR TITLE
Bugfix/Wrong screen reader announcement in quiz levels

### DIFF
--- a/services/site/src/components/challenge/level/QuizLevel.tsx
+++ b/services/site/src/components/challenge/level/QuizLevel.tsx
@@ -56,7 +56,7 @@ const QuizLevel: React.FunctionComponent<QuizLevelProps> = ({ levelId, question,
             className={clsx("mr-8 leading-tight tracking-wider font-mono col-span-4 text-5xl", "h2 prose", quizResult && "opacity-50")}
             dangerouslySetInnerHTML={{ __html: sanitizeHtml(question) }}
           />
-          <div className={clsx("col-span-3 mb-8 p-1 overflow-y-auto")}>
+          <div className={clsx("col-span-3 mb-8 p-1 overflow-y-auto")} role="status" aria-live="assertive">
             {quizResult === null && (
               <SingleAnswer srTitle={"Possible answers to the quiz"} answers={answers} chosenId={chosenId} onChooseId={setChosenId} />
             )}
@@ -98,18 +98,17 @@ const QuizLevel: React.FunctionComponent<QuizLevelProps> = ({ levelId, question,
         </div>
         <div className={clsx("flex justify-end mr-12 mb-12")}>
           {quizResult === null ? (
-            <LoadingButton
-              primary
-              onClick={submitLevel}
-              loading={loading}
-              submitButton
-              srTextLoading="The submission is being processed."
-              disabled={chosenId === null}
-            >
+            <LoadingButton primary onClick={submitLevel} loading={loading} submitButton disabled={chosenId === null}>
               Submit
             </LoadingButton>
           ) : (
-            <CompleteEvaluationButton status={quizResult.status} isLastLevel={isLastLevel} onRetry={reset} />
+            <CompleteEvaluationButton
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+              status={quizResult.status}
+              isLastLevel={isLastLevel}
+              onRetry={reset}
+            />
           )}
         </div>
       </section>

--- a/services/site/src/components/evaluation/CompleteEvaluationButton.tsx
+++ b/services/site/src/components/evaluation/CompleteEvaluationButton.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import React from "react";
 
 interface CompleteEvaluationButtonProps {
+  autoFocus?: boolean;
   status: ResultStatus;
   isLastLevel: boolean;
   className?: string;
@@ -14,6 +15,7 @@ interface CompleteEvaluationButtonProps {
 }
 
 export const CompleteEvaluationButton = ({
+  autoFocus,
   status,
   isLastLevel,
   className,
@@ -28,6 +30,8 @@ export const CompleteEvaluationButton = ({
   if (status === ResultStatus.Fail) {
     return (
       <LoadingButton
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocus}
         primary
         onClick={() => {
           setLoadingAnimation(true);
@@ -47,6 +51,8 @@ export const CompleteEvaluationButton = ({
   } else if (isLastLevel) {
     return (
       <LoadingButton
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocus}
         onClick={() => {
           router.push("/");
         }}
@@ -61,6 +67,8 @@ export const CompleteEvaluationButton = ({
   } else {
     return (
       <LoadingButton
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocus}
         onClick={() => {
           const nextLevel = parseInt(nthLevel as string) + 1;
           router.push(`/challenge/${challengeSlug}/level/0${nextLevel}`);


### PR DESCRIPTION
depends on 

# Description

- adds an aria-live region to the quiz level level to communicate the system status change
- shifts focus to the retry/next level button

Closes [#96](https://github.com/a11yphant/a11yphant/issues/96)

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher
- [x] Update ticket on the TODO board

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [ ] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)