### PR TITLE
Fix: Don't scroll to top of page when opening a challenge modal

### DIFF
--- a/services/site/src/components/homepage/Card.tsx
+++ b/services/site/src/components/homepage/Card.tsx
@@ -50,6 +50,7 @@ const Card: React.FunctionComponent<CardProps> = ({ className, heading, levels, 
           <Link
             href={`/?challenge=${challengeSlug}`}
             shallow={true}
+            scroll={false}
             className={clsx("border-transparent", "transition duration-300", "group-hover:text-grey-dark group-hover:border-transparent", "h6")}
           >
             {heading}


### PR DESCRIPTION
# Description

- Prevent scroll to top after adding the query param

Closes 

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher
- [x] Update ticket on the TODO board
- [x] (if .env file changes) Notify other team members

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)