### PR TITLE
Add overflow-wrap: anywhere to code

### DIFF
--- a/services/site/tailwind.config.js
+++ b/services/site/tailwind.config.js
@@ -73,6 +73,7 @@ module.exports = {
               color: theme("colors.primary.light"),
               fontFamily: theme("fontFamily.mono").join(" "),
               fontSize: "1em",
+              overflowWrap: "anywhere",
               "&::before": {
                 // cannot overwrite the content without important...
                 content: "none !important",


### PR DESCRIPTION
# Description

- Adds overflowWrap: anywhere to the code tags (in hints, intructions etc.)
- Otherwise, long tags expand the sidebar to be larger than intended

Closes 

## Definition of Done

### General

- [ ] Code Review
- [x] Test Coverage is equal or higher

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)