### PR TITLE
fix(QuizLevel): only show congratulations flash message at the right …

### DIFF
--- a/services/site/src/components/challenge/level/QuizLevel.tsx
+++ b/services/site/src/components/challenge/level/QuizLevel.tsx
@@ -21,7 +21,7 @@ interface QuizLevelProps {
 
 const QuizLevel: React.FunctionComponent<QuizLevelProps> = ({ levelId, question, answers, isLastLevel }) => {
   const [chosenId, setChosenId] = React.useState<string>(null);
-  const [quizResult, setQuizResult] = React.useState<{ id: string; status: ResultStatus }>(null);
+  const [quizResult, setQuizResult] = React.useState<{ levelId: string; id: string; status: ResultStatus }>(null);
   const flashMessageApi = useFlashMessageApi();
 
   const [submitQuizLevelAnswerMutation, { loading }] = useSubmitQuizLevelAnswerMutation();
@@ -29,7 +29,7 @@ const QuizLevel: React.FunctionComponent<QuizLevelProps> = ({ levelId, question,
   const submitLevel = async (): Promise<void> => {
     const { data } = await submitQuizLevelAnswerMutation({ variables: { input: { levelId: levelId, answers: [chosenId] } } });
 
-    setQuizResult(data.submitQuizLevelAnswer.result);
+    setQuizResult({ levelId, ...data.submitQuizLevelAnswer.result });
   };
 
   const reset = (): void => {
@@ -42,7 +42,7 @@ const QuizLevel: React.FunctionComponent<QuizLevelProps> = ({ levelId, question,
   }, [levelId]);
 
   React.useEffect(() => {
-    if (isLastLevel && quizResult?.status === ResultStatus.Success) {
+    if (isLastLevel && quizResult?.levelId === levelId && quizResult?.status === ResultStatus.Success) {
       flashMessageApi.show(<ChallengeCompletedFlashMessage />);
     }
   }, [quizResult?.status, isLastLevel]);


### PR DESCRIPTION
# Description

Previously, the flash message was shown before answering the last level correctly if the previous level also was a quiz level. Now it is only shown after answering the last quiz level correctly.

Closes 

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)