### PR TITLE
Fix Styling of Links in Instructions

### DIFF
--- a/services/site/src/styles/custom.scss
+++ b/services/site/src/styles/custom.scss
@@ -68,17 +68,6 @@
     @apply inline-block;
 }
 
-.instruction-text a {
-    @apply text-grey;
-    @apply focus-rounded-instead-of-underline;
-    @apply no-underline;
-    @apply border-light;
-
-    &:hover {
-        @apply border-transparent;
-    }
-}
-
 // Reduced Motion ---
 @media (prefers-reduced-motion: no-preference) {
     :focus {

--- a/services/site/src/styles/custom.scss
+++ b/services/site/src/styles/custom.scss
@@ -68,6 +68,17 @@
     @apply inline-block;
 }
 
+.instruction-text a {
+    @apply text-grey;
+    @apply focus-rounded-instead-of-underline;
+    @apply no-underline;
+    @apply border-light;
+
+    &:hover {
+        @apply border-transparent;
+    }
+}
+
 // Reduced Motion ---
 @media (prefers-reduced-motion: no-preference) {
     :focus {

--- a/services/site/tailwind.config.js
+++ b/services/site/tailwind.config.js
@@ -82,6 +82,14 @@ module.exports = {
                 content: "none !important",
               },
             },
+            a: {
+              color: theme("colors.grey.DEFAULT"),
+              textDecorationLine: "none",
+              borderColor: theme("colors.white"),
+              "&:hover": {
+                borderColor: theme("colors.transparent"),
+              },
+            },
           },
         },
       }),

--- a/services/site/tailwind.config.js
+++ b/services/site/tailwind.config.js
@@ -86,7 +86,9 @@ module.exports = {
               color: theme("colors.grey.DEFAULT"),
               textDecorationLine: "none",
               borderColor: theme("colors.white"),
+              fontWeight: theme("fontWeight.normal"),
               "&:hover": {
+                color: theme("colors.primary.light"),
                 borderColor: theme("colors.transparent"),
               },
             },

--- a/services/site/tailwind.config.js
+++ b/services/site/tailwind.config.js
@@ -85,7 +85,7 @@ module.exports = {
             a: {
               color: theme("colors.grey.DEFAULT"),
               textDecorationLine: "none",
-              borderColor: theme("colors.white"),
+              borderColor: theme("colors.grey.DEFAULT"),
               fontWeight: theme("fontWeight.normal"),
               "&:hover": {
                 color: theme("colors.primary.light"),

--- a/services/site/tailwind.config.js
+++ b/services/site/tailwind.config.js
@@ -91,6 +91,11 @@ module.exports = {
                 color: theme("colors.primary.light"),
                 borderColor: theme("colors.transparent"),
               },
+              "&:focus": {
+                borderRadius: theme("borderRadius.DEFAULT"),
+                borderColor: theme("colors.transparent"),
+                outlineOffset: theme("outlineOffset.4"),
+              },
             },
           },
         },


### PR DESCRIPTION
# Description

- previously links in the instruction text were almost unreadable
- now they are properly highlighted



https://github.com/a11yphant/a11yphant/assets/13380047/9e13fb3f-0289-4ed9-810b-7b10a7046c5d




Closes 

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)