### PR TITLE
Adjust Code Level Styles on Mobile

### DIFF
--- a/services/site/src/components/challenge/Editors.tsx
+++ b/services/site/src/components/challenge/Editors.tsx
@@ -17,7 +17,7 @@ interface CustomEditorProps extends Omit<EditorProps, "language" | "value" | "on
 
 const Editors: React.FunctionComponent<CustomEditorProps> = ({ className, editors, onReset, ...props }) => {
   return (
-    <div className={clsx("pb-4 flex flex-row justify-between box-border", className)}>
+    <div className={clsx("pb-4 flex flex-col justify-between box-border", "md:flex-row", className)}>
       {editors.map((config) => (
         <WrappedEditor onReset={onReset} key={config.heading} config={config} {...props} />
       ))}

--- a/services/site/src/components/challenge/editor/WrappedEditor.tsx
+++ b/services/site/src/components/challenge/editor/WrappedEditor.tsx
@@ -109,7 +109,7 @@ const WrappedEditor: React.FunctionComponent<CustomEditorProps> = ({ onReset, co
   });
 
   return (
-    <div className={clsx("w-inherit h-full px-2", "first:pl-0 last:pr-0")}>
+    <div className={clsx("w-inherit h-full p-2", "md:py-0 md:first:pl-0 md:last:pr-0")}>
       <div ref={wrapperRef} className={clsx("relative", "px-4 py-3 sm:p-4 w-inherit h-full", "container-dark overflow-hidden")}>
         <div className={clsx("flex flex-row justify-between")}>
           <h3 ref={headingRef} className={clsx("mb-5 sm:mx-3", "h6")}>

--- a/services/site/src/components/challenge/sidebar/HintBox.tsx
+++ b/services/site/src/components/challenge/sidebar/HintBox.tsx
@@ -51,7 +51,7 @@ const HintBox: React.FunctionComponent<HintBoxProps> = ({ hints }) => {
             {hints.slice(0, usedHints).map((hint) => (
               <li
                 key={hint.id}
-                className={clsx("mt-2 mb-4 whitespace-pre-wrap", "prose text-lg leading-8")}
+                className={clsx("mt-2 mb-4 whitespace-pre-wrap", "prose leading-8", "md:text-lg")}
                 dangerouslySetInnerHTML={{ __html: sanitizeHtml(hint.text) }}
               />
             ))}


### PR DESCRIPTION
# Description

- make font size of hint text as small as instructions
- display multiple editors underneath each other

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)