### PR TITLE
fix: link color on home page

### DIFF
--- a/services/site/src/pages/index.tsx
+++ b/services/site/src/pages/index.tsx
@@ -114,7 +114,7 @@ const Home: React.VoidFunctionComponent<HomeProps> = ({ fmType }) => {
                 overrideClassName
                 className="text-grey-middle font-sans font-normal border-grey-middle
         transition-colors duration-300
-        hover:text-primary-grey-middle hover:border-transparent
+        hover:text-primary-light hover:border-transparent
         focus-rounded-instead-of-underline"
               >
                 Twitter account


### PR DESCRIPTION
# Description

- right link hover color got lost somehow in the last release

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)