### PR TITLE
Feature/ Level complete number

### DIFF
--- a/services/site/src/components/homepage/Card.tsx
+++ b/services/site/src/components/homepage/Card.tsx
@@ -50,7 +50,7 @@ const Card: React.FunctionComponent<CardProps> = ({
         </span>
       )}
 
-      {((finishedLevels > 0 && finishedLevels !== levels) || (finishedLevels >= 0 && challengeStatus === ChallengeStatus.InProgress)) && (
+      {challengeStatus === ChallengeStatus.InProgress && (
         <div className={clsx("flex-1 flex items-center justify-center")}>
           <p className={clsx("text-background-light font-mono text-6xl mb-0", "transition duration-300", "group-hover:text-grey-dark")}>
             {finishedLevels}/{levels} <span className={clsx("sr-only")}>levels completed</span>

--- a/services/site/src/components/homepage/Card.tsx
+++ b/services/site/src/components/homepage/Card.tsx
@@ -1,6 +1,6 @@
 import { getDifficultyIconByChallengeDifficulty } from "app/components/homepage/difficulties/Difficulties";
 import Check from "app/components/icons/Check";
-import { ChallengeDifficulty } from "app/generated/graphql";
+import { ChallengeDifficulty, ChallengeStatus } from "app/generated/graphql";
 import clsx from "clsx";
 import Link from "next/link";
 import React from "react";
@@ -14,6 +14,7 @@ export interface CardProps {
   challengeSlug: string;
   challengeNumber: number;
   isMobileFriendly?: boolean;
+  challengeStatus: ChallengeStatus;
 }
 
 const Card: React.FunctionComponent<CardProps> = ({
@@ -25,6 +26,7 @@ const Card: React.FunctionComponent<CardProps> = ({
   challengeSlug,
   challengeNumber,
   isMobileFriendly,
+  challengeStatus,
 }) => {
   const DifficultyIcon = getDifficultyIconByChallengeDifficulty(difficulty);
 
@@ -48,7 +50,7 @@ const Card: React.FunctionComponent<CardProps> = ({
         </span>
       )}
 
-      {finishedLevels > 0 && finishedLevels !== levels && (
+      {((finishedLevels > 0 && finishedLevels !== levels) || (finishedLevels >= 0 && challengeStatus === ChallengeStatus.InProgress)) && (
         <div className={clsx("flex-1 flex items-center justify-center")}>
           <p className={clsx("text-background-light font-mono text-6xl mb-0", "transition duration-300", "group-hover:text-grey-dark")}>
             {finishedLevels}/{levels} <span className={clsx("sr-only")}>levels completed</span>

--- a/services/site/src/components/homepage/ChallengeList.tsx
+++ b/services/site/src/components/homepage/ChallengeList.tsx
@@ -37,6 +37,7 @@ const ChallengeList: React.FunctionComponent<ChallengeListProps> = ({ className,
             finishedLevels={challenge.numberOfFinishedLevels}
             difficulty={challenge.difficulty}
             challengeNumber={challenges.length}
+            challengeStatus={challenge.status}
           />
         ))}
       </ul>

--- a/services/site/tests/components/homepage/Card.spec.tsx
+++ b/services/site/tests/components/homepage/Card.spec.tsx
@@ -1,6 +1,6 @@
 import { render, RenderResult, screen } from "@testing-library/react";
 import Card, { CardProps } from "app/components/homepage/Card";
-import { ChallengeDifficulty } from "app/generated/graphql";
+import { ChallengeDifficulty, ChallengeStatus } from "app/generated/graphql";
 import React from "react";
 
 const headingText = "Semantic HTML";
@@ -16,6 +16,7 @@ const card = (
     finishedLevels={0}
     difficulty={ChallengeDifficulty.Easy}
     challengeNumber={1}
+    challengeStatus={ChallengeStatus.InProgress}
   />
 );
 


### PR DESCRIPTION
# Description

The number on the home page indicating how many levels are completed should start with 0. Then it will be displayed after clicking into a challenge without submitting changes for evaluation.

This ensures better usability and hopefully UX.

Closes [Level Completed Number#42](https://github.com/a11yphant/issues/issues/42)

## Definition of Done

### General

- [ ] Code Review
- [x] Test Coverage is equal or higher
- [x] Update ticket on the TODO board

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)