### PR TITLE
Add margin-between-elements-greater-than-or-equal check

### DIFF
--- a/services/api/src/submission/checks/base-checks/index.ts
+++ b/services/api/src/submission/checks/base-checks/index.ts
@@ -10,6 +10,7 @@ import { ElementHasMinimumDimension } from "./element-has-minimum-dimension";
 import { ElementNotContainsText } from "./element-not-contains-text.check";
 import { ElementNotExists } from "./element-not-exists.check";
 import { HtmlIsValid } from "./html-is-valid.check";
+import { MarginBetweenElementsGreaterThanOrEqual } from "./margin-between-elements-greater-than-or-equal.check";
 
 export {
   AxeCheck,
@@ -24,4 +25,5 @@ export {
   ElementNotContainsText,
   ElementNotExists,
   HtmlIsValid,
+  MarginBetweenElementsGreaterThanOrEqual,
 };

--- a/services/api/src/submission/checks/base-checks/margin-between-elements-greater-than-or-equal.check.ts
+++ b/services/api/src/submission/checks/base-checks/margin-between-elements-greater-than-or-equal.check.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { DOMWindow } from "jsdom";
+
+import { CodeLevelSubmission as Submission } from "../../graphql/models/code-level-submission.model";
+import { Rule } from "../../interfaces/rule.interface";
+import { RuleCheckResult } from "../../interfaces/rule-check-result.interface";
+import { JsdomCheck } from "./jsdom-check";
+
+@Injectable()
+export class MarginBetweenElementsGreaterThanOrEqual extends JsdomCheck {
+  constructor(logger: Logger) {
+    super(logger);
+  }
+
+  public async evaluateRule(window: DOMWindow, submission: Submission, rule: Rule): Promise<RuleCheckResult> {
+    for (const option of ["selector1", "selector2", "value"]) {
+      if (!this.ruleHasOption(rule, option)) {
+        return this.checkConfigurationError(submission, rule, option);
+      }
+    }
+
+    const { selector1, selector2, value: cssValue } = rule.options;
+    const element1 = window.document.querySelector(selector1);
+    const element2 = window.document.querySelector(selector2);
+
+    if (element1 === null || element2 === null) {
+      return {
+        id: rule.id,
+        status: "failed",
+      };
+    }
+
+    const cssValueFloat = parseFloat(cssValue);
+    if (isNaN(cssValueFloat)) {
+      return this.checkFailed(new Error("Passed value is not a valid number."), submission, rule);
+    }
+
+    const style1 = window.getComputedStyle(element1);
+    const style2 = window.getComputedStyle(element2);
+
+    const margin1 = style1.marginRight ? parseFloat(style1.marginRight) : parseFloat(style1.margin);
+    const margin2 = style2.marginLeft ? parseFloat(style2.marginLeft) : parseFloat(style2.margin);
+
+    return {
+      id: rule.id,
+      status: margin1 + margin2 >= cssValueFloat ? "success" : "failed",
+    };
+  }
+}

--- a/services/api/src/submission/checks/check-to-class-map.ts
+++ b/services/api/src/submission/checks/check-to-class-map.ts
@@ -1,3 +1,5 @@
+import { MarginBetweenElementsGreaterThanOrEqual } from "@/submission/checks/base-checks/margin-between-elements-greater-than-or-equal.check";
+
 import { AXE_CHECKS_TO_CHECK_NAMES_MAP } from "./axe-checks";
 import {
   ColorContrastGreaterThanOrEqual,
@@ -25,6 +27,7 @@ export const checkToClassMap = {
   "document-language-is-specified": DocumentLanguageIsSpecified,
   "document-starts-with-html5-doctype": DocumentStartsWithHtml5Doctype,
   "color-contrast-greater-than-or-equal": ColorContrastGreaterThanOrEqual,
+  "margin-between-elements-greater-than-or-equal": MarginBetweenElementsGreaterThanOrEqual,
   ...AXE_CHECKS_TO_CHECK_NAMES_MAP,
 };
 

--- a/services/api/src/submission/submission.module.ts
+++ b/services/api/src/submission/submission.module.ts
@@ -16,6 +16,7 @@ import {
   ElementNotContainsText,
   ElementNotExists,
   HtmlIsValid,
+  MarginBetweenElementsGreaterThanOrEqual,
 } from "./checks/base-checks";
 import { CheckFactory } from "./checks/check.factory";
 import { CHECK_TO_CLASS_MAP, checkToClassMap } from "./checks/check-to-class-map";
@@ -60,6 +61,7 @@ import { RequirementResultService } from "./services/requirement-result.service"
     ElementNotExists,
     ElementHasMinimumDimension,
     HtmlIsValid,
+    MarginBetweenElementsGreaterThanOrEqual,
     ...buildCheckProviders(AVAILABLE_AXE_CHECKS),
   ],
   exports: [CodeLevelSubmissionService],

--- a/services/api/tests/unit/submission/checks/margin-between-elements-greater-than-or-equal.check.spec.ts
+++ b/services/api/tests/unit/submission/checks/margin-between-elements-greater-than-or-equal.check.spec.ts
@@ -1,0 +1,166 @@
+import { createMock } from "@golevelup/ts-jest";
+import { Logger } from "@nestjs/common";
+import { createRule, createSubmission } from "@tests/support/helpers";
+
+import { MarginBetweenElementsGreaterThanOrEqual } from "@/submission/checks/base-checks/margin-between-elements-greater-than-or-equal.check";
+
+describe("margin-between-elements-greater-than-or-equal", () => {
+  const submission = createSubmission({
+    html: "<html><button>One</button><button>Two</button></html>",
+    css: "button { margin: 10px } button:nth-of-type(1) { margin-right: 10px } button:nth-of-type(2) { margin-left: 10px }",
+  });
+
+  const rule = createRule({
+    key: "margin-between-elements-greater-than-or-equal",
+    options: {
+      selector1: "button:nth-of-type(1)",
+      selector2: "button:nth-of-type(2)",
+      value: "20px",
+    },
+  });
+
+  const getCheck = (): MarginBetweenElementsGreaterThanOrEqual => new MarginBetweenElementsGreaterThanOrEqual(createMock<Logger>());
+
+  it("fails if selector1 was not found", async () => {
+    const submission = createSubmission({
+      html: "<html></html>",
+      css: "",
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "failed");
+  });
+
+  it("fails if selector2 was not found", async () => {
+    const submission = createSubmission({
+      html: "<html><button>One</button></html>",
+      css: "h1 { font-size:  12px; }",
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "failed");
+  });
+
+  it("fails if combined margins are smaller than the value", async () => {
+    const submission = createSubmission({
+      html: "<html><button>One</button><button>Two</button></html>",
+      css: "button:nth-of-type(1) { margin-right: 5px } button:nth-of-type(2) { margin-left: 5px }",
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "failed");
+  });
+
+  it("is successful if combined margins are equal to the value", async () => {
+    const submission = createSubmission({
+      html: "<html><button>One</button><button>Two</button></html>",
+      css: "button:nth-of-type(1) { margin-right: 10px } button:nth-of-type(2) { margin-left: 10px }",
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "success");
+  });
+
+  it("is successful if combined margins are greater than the value", async () => {
+    const submission = createSubmission({
+      html: "<html><button>One</button><button>Two</button></html>",
+      css: "button:nth-of-type(1) { margin: 15px } button:nth-of-type(2) { margin-left: 15px }",
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "success");
+  });
+
+  it("marginLeft and marginRight override margin", async () => {
+    const submission = createSubmission({
+      html: "<html><button>One</button><button>Two</button></html>",
+      css: "button { margin: 15px } button:nth-of-type(1) { margin-right: 1px } button:nth-of-type(2) { margin-left: 1px }",
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "failed");
+  });
+
+  it("errors if the value cannot be parsed", async () => {
+    const rule = createRule({
+      key: "element-has-css-property-value-greater-than",
+      options: {
+        selector1: "button:nth-of-type(1)",
+        selector2: "button:nth-of-type(2)",
+        value: "string",
+      },
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "error");
+  });
+
+  it("errors if selector1 is missing", async () => {
+    const rule = createRule({
+      key: "element-has-css-property-value-greater-than",
+      options: {
+        selector2: "button:nth-of-type(2)",
+        value: "20px",
+      },
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "error");
+  });
+
+  it("errors if selector2 is missing", async () => {
+    const rule = createRule({
+      key: "element-has-css-property-value-greater-than",
+      options: {
+        selector1: "button:nth-of-type(1)",
+        value: "20px",
+      },
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "error");
+  });
+
+  it("errors if the value is missing", async () => {
+    const rule = createRule({
+      key: "element-has-css-property-value-greater-than",
+      options: {
+        selector1: "button:nth-of-type(1)",
+        selector2: "button:nth-of-type(2)",
+      },
+    });
+
+    const check = getCheck();
+    const result = await check.run(submission, rule);
+
+    expect(result).toHaveProperty("id", rule.id);
+    expect(result).toHaveProperty("status", "error");
+  });
+});


### PR DESCRIPTION
depends on 

# Description

- Add new margin-between-elements-greater-than-or-equal check

This check is meant to make the requirement in challenge buttons / level 7 a bit less specific. Since we don't actually render the site anymore but use JSDOM, we can't calculate distances between rendered elements. So we have to rely on the user to solve the challenge using margin (although there are many other ways like making the parent a flexbox with space-between).

Closes #188

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher
- [x] Update ticket on the TODO board