### PR TITLE
Add default CSS for link styling

### DIFF
--- a/services/api/src/submission/checks/base-checks/jsdom-check.ts
+++ b/services/api/src/submission/checks/base-checks/jsdom-check.ts
@@ -2,6 +2,8 @@ import { Logger } from "@nestjs/common";
 import { JSDOM } from "jsdom";
 import { DOMWindow } from "jsdom";
 
+import { defaultLinkStylingCss } from "@/submission/checks/default-css";
+
 import { CodeLevelSubmission as Submission } from "../../graphql/models/code-level-submission.model";
 import { Rule } from "../../interfaces/rule.interface";
 import { RuleCheckResult } from "../../interfaces/rule-check-result.interface";
@@ -17,13 +19,14 @@ export abstract class JsdomCheck extends BaseCheck {
   public async run(submission: Submission, rule: Rule): Promise<RuleCheckResult> {
     try {
       const { window } = new JSDOM(submission.html);
+      const stylesheet = window.document.createElement("style");
+      stylesheet.innerHTML = defaultLinkStylingCss;
 
       if (submission.css) {
-        const stylesheet = window.document.createElement("style");
-        stylesheet.innerHTML = submission.css;
-        const head = window.document.getElementsByTagName("head")[0];
-        head.appendChild(stylesheet);
+        stylesheet.innerHTML += submission.css;
       }
+      const head = window.document.getElementsByTagName("head")[0];
+      head.appendChild(stylesheet);
 
       return this.evaluateRule(window, submission, rule);
     } catch (error) {

--- a/services/api/src/submission/checks/default-css.ts
+++ b/services/api/src/submission/checks/default-css.ts
@@ -1,0 +1,10 @@
+// most default CSS is handled by JSDOM in https://github.com/jsdom/jsdom/blob/main/lib/jsdom/browser/default-stylesheet.js
+// but some styles are missing for an unknown reason
+
+// styling for links based on https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3
+export const defaultLinkStylingCss = `
+    :link { color: #0000EE; }
+    :visited { color: #551A8B; }
+    :link:active, :visited:active { color: #FF0000; }
+    :link, :visited { text-decoration: underline; cursor: pointer; }
+`;


### PR DESCRIPTION
depends on 

# Description

JSDOM already has an implementation for a default stylesheet: [default-stylesheet.js](https://github.com/jsdom/jsdom/blob/main/lib/jsdom/browser/default-stylesheet.js). This is based on the [Chromium implementation](https://chromium.googlesource.com/chromium/blink/+/96aa3a280ab7d67178c8f122a04949ce5f8579e0/Source/core/css/html.css). However, some selectors use webkit-specific pseudo classes. It appears they were removed in the JSDOM copy. This affects the link because the following CSS from Chromium is missing:

```
a:-webkit-any-link {
  color: -webkit-link;
  text-decoration: underline;
  cursor: auto;
}
```

So I only added the default link styling for now

Closes https://github.com/a11yphant/issues/issues/47

## Definition of Done

### General

- [x] Code Review
- [x] Test Coverage is equal or higher
- [x] Update ticket on the TODO board