### PR TITLE
Fix behavior of links within HintBox

### DIFF
--- a/services/site/src/components/challenge/sidebar/HintBox.tsx
+++ b/services/site/src/components/challenge/sidebar/HintBox.tsx
@@ -19,7 +19,7 @@ const HintBox: React.FunctionComponent<HintBoxProps> = ({ hints }) => {
   const prefersReducedMotion = usePrefersReducedMotion();
 
   return (
-    <div className={clsx("flex flex-col", "container-ultra-dark card-smaller")}>
+    <div className={clsx("flex flex-col", "container-ultra-dark hint-box")}>
       <h4 className={clsx("w-full")}>
         <Button
           onClick={() => {

--- a/services/site/src/styles/custom.scss
+++ b/services/site/src/styles/custom.scss
@@ -44,9 +44,7 @@
     }
 }
 
-.card-smaller {
-    @include card;
-
+.hint-box {
     &:focus-within {
         outline: 3px solid #fff;
     }


### PR DESCRIPTION
depends on 

# Description

- Separate hint-box styling from card styling to remove specific handling of <a> elements

Closes 

## Definition of Done

### General

- [ ] Code Review
- [x] Test Coverage is equal or higher

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)