### PR TITLE
Remove jest-dom 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,6 @@
         "gray-matter": "4.0.3",
         "husky": "9.1.5",
         "jest": "29.7.0",
-        "jest-dom": "4.0.0",
         "jest-environment-jsdom": "29.7.0",
         "jest-fail-on-console": "3.3.0",
         "jest-fetch-mock": "3.0.3",
@@ -17725,13 +17724,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-dom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jest-dom/-/jest-dom-4.0.0.tgz",
-      "integrity": "sha512-gBxYZlZB1Jgvf2gP2pRfjjUWF8woGBHj/g5rAQgFPB/0K2atGuhVcPO+BItyjWeKg9zM+dokgcMOH01vrWVMFA==",
-      "deprecated": "🚨 jest-dom has moved to @testing-library/jest-dom. Please uninstall jest-dom and install @testing-library/jest-dom instead, or use an older version of jest-dom. Learn more about this change here: https://github.com/testing-library/dom-testing-library/issues/260 Thanks! :)",
-      "dev": true
     },
     "node_modules/jest-each": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
     "gray-matter": "4.0.3",
     "husky": "9.1.5",
     "jest": "29.7.0",
-    "jest-dom": "4.0.0",
     "jest-environment-jsdom": "29.7.0",
     "jest-fail-on-console": "3.3.0",
     "jest-fetch-mock": "3.0.3",


### PR DESCRIPTION
`jest-dom` was deprecated in favor of `@testing-library/jest-dom`
