### PR TITLE
Manage the session cookie in the nextjs middleware

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,6 +64,7 @@ jobs:
         ports:
           - 5432:5432
     env:
+      API_KEY: "I-am-a-very-secret-key"
       SITE_HOST: localhost
       SITE_PORT: 3001
       SITE_GRAPHQL_ENDPOINT_SERVER: http://localhost:3000/graphql

--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -31,12 +31,13 @@ function createUser({ name, email, password }) {
 describe("login", () => {
   it("can login", () => {
     Cypress.Cookies.debug(true);
+    cy.visit("/");
     createUser({
       name: "Login user",
       email: "login@a11yphant.com",
       password: "very-secret",
     });
-    cy.visit("/");
+    cy.reload();
     cy.contains("button", "Login").click();
     getInputByLabel("Email", loginContainer()).type("login@a11yphant.com");
     getInputByLabel("Password", loginContainer()).type("very-secret");

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "focus-visible": "5.2.1",
         "graphql": "16.9.0",
         "handlebars": "4.7.8",
+        "jose": "5.8.0",
         "js-yaml": "4.1.0",
         "jsdom": "^25.0.0",
         "jsonwebtoken": "9.0.2",
@@ -19186,7 +19187,7 @@
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/jose/-/jose-5.8.0.tgz",
       "integrity": "sha512-E7CqYpL/t7MMnfGnK/eg416OsFCVUrU/Y3Vwe7QjKhu/BkS1Ms455+2xsqZQVN57/U2MHMBvEb5SrmAZWAIntA==",
-      "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "focus-visible": "5.2.1",
     "graphql": "16.9.0",
     "handlebars": "4.7.8",
+    "jose": "5.8.0",
     "js-yaml": "4.1.0",
     "jsdom": "^25.0.0",
     "jsonwebtoken": "9.0.2",

--- a/src/api/authentication/session.interceptor.ts
+++ b/src/api/authentication/session.interceptor.ts
@@ -3,14 +3,11 @@ import { ConfigService } from "@nestjs/config";
 import { GqlContextType, GqlExecutionContext } from "@nestjs/graphql";
 import { Request } from "express";
 import { Observable } from "rxjs";
-import { tap } from "rxjs/operators";
 
 import { UserService } from "@/user/user.service";
 
-import { JwtScope } from "./enums/jwt-scope.enum";
 import { Context } from "./interfaces/context.interface";
 import { JwtSessionCookie } from "./interfaces/jwt-session-cookie.interface";
-import { SessionToken } from "./interfaces/session-token.interface";
 import { JwtService } from "./jwt.service";
 
 @Injectable()
@@ -32,40 +29,24 @@ export class SessionInterceptor implements NestInterceptor {
 
   async handleGql(context: Context, next: CallHandler): Promise<Observable<any>> {
     const sessionCookie = context.req.cookies[this.config.get<string>("cookie.name")];
+
+    // token was already verified in the middleware
     const { sub: userId } = this.jwtService.decodeToken<JwtSessionCookie>(sessionCookie) || {};
 
-    if ((await this.jwtService.validateToken(sessionCookie, JwtScope.SESSION)) && (await this.userService.findById(userId))) {
-      context.sessionToken = { userId };
-      return next.handle();
-    }
+    await this.userService.createIfNotExists(userId);
 
-    const user = await this.userService.create();
+    context.sessionToken = { userId };
 
-    const newToken: SessionToken = {
-      userId: user.id,
-    };
-
-    context.sessionToken = newToken;
-
-    const token = await this.jwtService.createSignedToken(
-      { scope: JwtScope.SESSION },
-      { subject: newToken.userId, expiresInSeconds: 3600 * 24 * 365 },
-    );
-    return next.handle().pipe(
-      tap(() => {
-        context.res.cookie(this.config.get<string>("cookie.name"), token, this.config.get("cookie.defaultConfig"));
-      }),
-    );
+    return next.handle();
   }
 
   async handleHttp(executionContext: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
     const req = executionContext.switchToHttp().getRequest<Request & { sessionToken: any }>();
     const sessionCookie = req.cookies[this.config.get<string>("cookie.name")];
 
-    if (await this.jwtService.validateToken(sessionCookie, JwtScope.SESSION)) {
-      const { sub: userId } = this.jwtService.decodeToken<JwtSessionCookie>(sessionCookie);
-      req.sessionToken = { userId };
-    }
+    const { sub: userId } = this.jwtService.decodeToken<JwtSessionCookie>(sessionCookie);
+    req.sessionToken = { userId };
+
     return next.handle();
   }
 }

--- a/src/api/authentication/store.service.ts
+++ b/src/api/authentication/store.service.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { Request } from "express";

--- a/src/api/user/exceptions/transaction-retries-exhausted.error.ts
+++ b/src/api/user/exceptions/transaction-retries-exhausted.error.ts
@@ -1,0 +1,5 @@
+export class TransactionRetriesExhaustedError extends Error {
+  constructor() {
+    super("The number of retries for the transaction was exhausted");
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,9 @@
-import { from } from "@apollo/client";
-import { CurrentUserDocument, CurrentUserQuery } from "app/generated/graphql";
-import { createApolloClientRSC } from "app/lib/apollo-client/create-apollo-client-rsc";
-import { Cookie, createForwardCookiesToClientLink } from "app/lib/apollo-client/create-forward-cookies-to-client-link";
-import { SetCookieFunction } from "app/lib/apollo-client/create-forward-cookies-to-client-link";
-import { GetCookieHeaderFunction } from "app/lib/apollo-client/create-forward-cookies-to-server-link";
+import * as jose from "jose";
 import { NextRequest, NextResponse } from "next/server";
 
+import { JwtScope } from "./api/authentication/enums/jwt-scope.enum";
+import { JwtOptions } from "./api/authentication/interfaces/jwt-options.interface";
+import { SessionToken } from "./api/authentication/interfaces/session-token.interface";
 import { getConfig } from "./lib/config/rsc";
 
 type Middleware = {
@@ -46,40 +44,76 @@ const redirectChallengeUrls: Middleware = {
 };
 
 const authentication: Middleware = {
-  match: (req) => !req.cookies.has("a11yphant_session"),
+  match: (_) => true,
   run: async (req) => {
-    const { graphqlEndpointPath } = getConfig(req.headers.get("host"));
-    const cookies: Cookie[] = [];
+    if (req.cookies.has("a11yphant_session") && (await validateToken(req.cookies.get("a11yphant_session").value, JwtScope.SESSION))) {
+      const { sub: userId } = decodeToken(req.cookies.get("a11yphant_session").value);
+      const tokenData: SessionToken = {
+        userId,
+      };
 
-    const setCookie: SetCookieFunction = (cookie) => {
-      cookies.push(cookie);
-    };
+      const token = await createSignedToken({ scope: JwtScope.SESSION }, { subject: tokenData.userId, expiresInSeconds: 3600 * 24 * 365 });
 
-    const getCookiesHeader: GetCookieHeaderFunction = () => {
-      return req.headers.get("cookie");
-    };
+      const response = NextResponse.next();
 
-    const client = createApolloClientRSC(graphqlEndpointPath, getCookiesHeader);
-    client.setLink(from([createForwardCookiesToClientLink(setCookie), client.link]));
+      response.cookies.set({
+        name: "a11yphant_session",
+        value: token,
+        sameSite: "lax",
+        secure: true,
+        httpOnly: true,
+      });
 
-    await client.query<CurrentUserQuery>({
-      query: CurrentUserDocument,
-    });
-
-    for (const { name, value } of cookies) {
-      req.cookies.set(name, value);
+      return response;
     }
 
-    const response = NextResponse.next({
-      request: {
-        headers: new Headers(req.headers),
-      },
-    });
+    const tokenData: SessionToken = {
+      userId: self.crypto.randomUUID(),
+    };
 
-    for (const { name, value } of cookies) {
-      response.cookies.set(name, value);
-    }
+    const token = await createSignedToken({ scope: JwtScope.SESSION }, { subject: tokenData.userId, expiresInSeconds: 3600 * 24 * 365 });
+
+    const response = NextResponse.next();
+
+    response.cookies.set({
+      name: "a11yphant_session",
+      value: token,
+      sameSite: "lax",
+      secure: true,
+      httpOnly: true,
+    });
 
     return response;
   },
 };
+
+async function createSignedToken(content: Record<string, any>, options: JwtOptions): Promise<string> {
+  const secret = process.env.API_KEY;
+  const token = await new jose.SignJWT(content)
+    .setProtectedHeader({
+      alg: "HS256",
+    })
+    .setIssuer("a11yphant")
+    .setSubject(options.subject)
+    .setExpirationTime(`${options.expiresInSeconds} seconds from now`)
+    .sign(Buffer.from(secret));
+
+  return token;
+}
+
+async function validateToken(token: string, scope: JwtScope): Promise<boolean> {
+  const secret = process.env.API_KEY;
+  try {
+    const { payload } = await jose.jwtVerify<{ scope: JwtScope }>(token, Buffer.from(secret), {
+      issuer: "a11yphant",
+    });
+
+    return scope === payload.scope;
+  } catch (e) {
+    return false;
+  }
+}
+
+function decodeToken<T extends Record<string, any>>(token: string): T {
+  return jose.decodeJwt<T>(token);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -79,7 +79,7 @@ const authentication: Middleware = {
       name: "a11yphant_session",
       value: token,
       sameSite: "lax",
-      secure: true,
+      secure: process.env.SITE_PROTOCOL === "https" ? true : false,
       httpOnly: true,
     });
 

--- a/tests/api/service/code-level.spec.ts
+++ b/tests/api/service/code-level.spec.ts
@@ -24,8 +24,10 @@ describe("code level", () => {
       data: Factory.build<CodeLevelData>(CODE_LEVEL),
     });
 
-    const graphqlClient = getGraphQlClient({ authCookie: cookie });
-    const { data } = await graphqlClient.mutate({
+    const graphqlClient = await getGraphQlClient({ authCookie: cookie });
+    const { data } = await (
+      await graphqlClient
+    ).mutate({
       mutation: gql`
         mutation createCodeLevelSubmission($submissionInput: CreateCodeLevelSubmissionInput!) {
           createCodeLevelSubmission(submissionInput: $submissionInput) {
@@ -66,7 +68,7 @@ describe("code level", () => {
       data: Factory.build<CodeLevelSubmissionData>(CODE_LEVEL_SUBMISSION, { user: { connect: { id: user.id } } }),
     });
 
-    const graphqlClient = getGraphQlClient({ authCookie: cookie });
+    const graphqlClient = await getGraphQlClient({ authCookie: cookie });
     const { data } = await graphqlClient.mutate({
       mutation: gql`
         mutation requestCodeLevelCheck($requestCheckInput: RequestCodeLevelCheckInput!) {
@@ -109,7 +111,7 @@ describe("code level", () => {
       }),
     });
 
-    const graphqlClient = getGraphQlClient({ authCookie: cookie });
+    const graphqlClient = await getGraphQlClient({ authCookie: cookie });
     const { data } = await graphqlClient.query({
       query: gql`
         query resultForSubmission($id: String!) {

--- a/tests/api/service/current-user.spec.ts
+++ b/tests/api/service/current-user.spec.ts
@@ -12,7 +12,9 @@ describe("current user", () => {
   const { getGraphQlClient, getApp } = useTestingApp();
 
   it("returns an anonymous user if the user is not registered", async () => {
-    const { data } = await getGraphQlClient().query({
+    const { data } = await (
+      await getGraphQlClient()
+    ).query({
       query: gql`
         query currentUser {
           currentUser {
@@ -33,7 +35,7 @@ describe("current user", () => {
 
     const { cookie, user } = await createUserWithSessionCookie(prisma, app);
 
-    const graphqlClient = getGraphQlClient({ authCookie: cookie });
+    const graphqlClient = await getGraphQlClient({ authCookie: cookie });
     const { data } = await graphqlClient.query({
       query: gql`
         query currentUser {

--- a/tests/api/unit/authentication/authentication.controller.spec.ts
+++ b/tests/api/unit/authentication/authentication.controller.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";

--- a/tests/api/unit/authentication/graphql/resolvers/autentication.resolver.spec.ts
+++ b/tests/api/unit/authentication/graphql/resolvers/autentication.resolver.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { ConfigService } from "@nestjs/config";
 import { UserFactory } from "@tests/support/factories/models/user.factory";

--- a/tests/api/unit/authentication/session.interceptor.spec.ts
+++ b/tests/api/unit/authentication/session.interceptor.spec.ts
@@ -1,10 +1,14 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { ExecutionContext, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { UserFactory } from "@tests/support/factories/models/user.factory";
 import { createConfigServiceMock } from "@tests/support/helpers";
 import { runInterceptor } from "@tests/support/helpers";
-import { Request, Response } from "express";
+import { Request } from "express";
 
 import { Context } from "@/authentication/interfaces/context.interface";
 import { JwtService } from "@/authentication/jwt.service";
@@ -16,7 +20,7 @@ const doNothing = (): void => {
 };
 
 describe("session interceptor", () => {
-  it("handles normal requests", (done) => {
+  it("handles regular http requests", (done) => {
     expect.assertions(1);
     const executionContext = createMock<ExecutionContext>();
 
@@ -35,201 +39,11 @@ describe("session interceptor", () => {
     runInterceptor(interceptor, executionContext, doNothing, completeCallback, done);
   });
 
-  it("adds a session cookie to graphql requests", (done) => {
-    expect.assertions(2);
-    const cookie = jest.fn();
-    const context: Context = {
-      req: createMock<Request>(),
-      res: createMock<Response>({
-        cookie,
-      }),
-      sessionToken: null,
-    };
-    const executionContext = createMock<ExecutionContext>({
-      getType: jest.fn().mockReturnValue("graphql"),
-      getArgs: jest.fn().mockReturnValue([null, context, null]),
-    });
-
-    const interceptor = new SessionInterceptor(
-      createMock<JwtService>({
-        createSignedToken: jest.fn().mockResolvedValue("token"),
-        validateToken: jest.fn().mockResolvedValue(false),
-      }),
-      createMock<UserService>({
-        create: jest.fn().mockResolvedValue(UserFactory.build()),
-      }),
-      createMock<Logger>(),
-      createMock<ConfigService>(createConfigServiceMock()),
-    );
-
-    const nextCallback = (): void => {
-      expect(cookie).toHaveBeenCalledWith("a11yphant_session", expect.anything(), expect.anything());
-    };
-
-    const completeCallback = (): void => {
-      expect(cookie).toHaveBeenCalledTimes(1);
-    };
-
-    runInterceptor(interceptor, executionContext, nextCallback, completeCallback, done);
-  });
-
-  it("the session cookie contains a signed jwt", (done) => {
-    expect.assertions(1);
-    const cookie = jest.fn();
-    const context: Context = {
-      req: createMock<Request>(),
-      res: createMock<Response>({
-        cookie,
-      }),
-      sessionToken: null,
-    };
-    const executionContext = createMock<ExecutionContext>({
-      getType: jest.fn().mockReturnValue("graphql"),
-      getArgs: jest.fn().mockReturnValue([null, context, null]),
-    });
-
-    const token = "signed-token";
-    const createSignedToken = jest.fn().mockResolvedValue(token);
-    const interceptor = new SessionInterceptor(
-      createMock<JwtService>({
-        createSignedToken,
-        validateToken: jest.fn().mockResolvedValue(false),
-      }),
-      createMock<UserService>({
-        create: jest.fn().mockResolvedValue(UserFactory.build()),
-      }),
-      createMock<Logger>(),
-      createMock<ConfigService>(createConfigServiceMock()),
-    );
-
-    const nextCallback = (): void => {
-      expect(cookie).toHaveBeenCalledWith(expect.any(String), token, expect.anything());
-    };
-
-    runInterceptor(interceptor, executionContext, nextCallback, doNothing, done);
-  });
-
-  it("does not set a new cookie if a cookie already exists", (done) => {
-    expect.assertions(1);
-    const cookie = jest.fn();
-    const context: Context = {
-      req: createMock<Request>({
-        cookies: { a11yphant_session: "cookie" as any },
-      }),
-      res: createMock<Response>({
-        cookie,
-      }),
-      sessionToken: null,
-    };
-    const executionContext = createMock<ExecutionContext>({
-      getType: jest.fn().mockReturnValue("graphql"),
-      getArgs: jest.fn().mockReturnValue([null, context, null]),
-    });
-
-    const interceptor = new SessionInterceptor(
-      createMock<JwtService>({
-        createSignedToken: jest.fn().mockResolvedValue("token"),
-        validateToken: jest.fn().mockResolvedValue(true),
-        decodeToken: jest.fn().mockReturnValue({}),
-      }),
-      createMock<UserService>({
-        create: jest.fn().mockResolvedValue(UserFactory.build()),
-        findByEmail: jest.fn().mockResolvedValue(UserFactory.build()),
-      }),
-      createMock<Logger>(),
-      createMock<ConfigService>(createConfigServiceMock()),
-    );
-
-    const nextCallback = (): void => {
-      expect(cookie).not.toHaveBeenCalled();
-    };
-
-    runInterceptor(interceptor, executionContext, nextCallback, doNothing, done);
-  });
-
-  it("overwrites the session cookie if it is invalid", (done) => {
-    expect.assertions(1);
-    const cookie = jest.fn();
-    const context: Context = {
-      req: createMock<Request>({
-        cookies: { a11yphant_session: "cookie" as any },
-      }),
-      res: createMock<Response>({
-        cookie,
-      }),
-      sessionToken: null,
-    };
-    const executionContext = createMock<ExecutionContext>({
-      getType: jest.fn().mockReturnValue("graphql"),
-      getArgs: jest.fn().mockReturnValue([null, context, null]),
-    });
-
-    const interceptor = new SessionInterceptor(
-      createMock<JwtService>({
-        createSignedToken: jest.fn().mockResolvedValue("token"),
-        validateToken: jest.fn().mockResolvedValue(false),
-      }),
-      createMock<UserService>({
-        create: jest.fn().mockResolvedValue(UserFactory.build()),
-      }),
-      createMock<Logger>(),
-      createMock<ConfigService>(createConfigServiceMock()),
-    );
-
-    const nextCallback = (): void => {
-      expect(cookie).toHaveBeenCalled();
-    };
-
-    runInterceptor(interceptor, executionContext, nextCallback, doNothing, done);
-  });
-
-  it("ignores the existing cookie if the user does not exist", (done) => {
-    expect.assertions(1);
-    const cookie = jest.fn();
-    const context: Context = {
-      req: createMock<Request>({
-        cookies: { a11yphant_session: "cookie" as any },
-      }),
-      res: createMock<Response>({
-        cookie,
-      }),
-      sessionToken: null,
-    };
-
-    const executionContext = createMock<ExecutionContext>({
-      getType: jest.fn().mockReturnValue("graphql"),
-      getArgs: jest.fn().mockReturnValue([null, context, null]),
-    });
-
-    const interceptor = new SessionInterceptor(
-      createMock<JwtService>({
-        createSignedToken: jest.fn().mockResolvedValue("token"),
-        validateToken: jest.fn().mockResolvedValue(true),
-        decodeToken: jest.fn().mockReturnValue({}),
-      }),
-      createMock<UserService>({
-        create: jest.fn().mockResolvedValue(UserFactory.build()),
-        findById: jest.fn().mockResolvedValue(null),
-      }),
-      createMock<Logger>(),
-      createMock<ConfigService>(createConfigServiceMock()),
-    );
-
-    const nextCallback = (): void => {
-      expect(cookie).toHaveBeenCalled();
-    };
-
-    runInterceptor(interceptor, executionContext, nextCallback, doNothing, done);
-  });
-
   it("adds the decoded session token to the context", (done) => {
     expect.assertions(1);
-    const cookie = jest.fn();
     const context: Context = {
       req: createMock<Request>(),
-      res: createMock<Response>({
-        cookie,
-      }),
+      res: null,
       sessionToken: null,
     };
     const executionContext = createMock<ExecutionContext>({
@@ -239,9 +53,7 @@ describe("session interceptor", () => {
 
     const interceptor = new SessionInterceptor(
       createMock<JwtService>({
-        createSignedToken: jest.fn().mockResolvedValue("token"),
         validateToken: jest.fn().mockResolvedValue(true),
-        decodeToken: jest.fn().mockReturnValue({ payload: "something" }),
       }),
       createMock<UserService>({
         create: jest.fn().mockResolvedValue(UserFactory.build()),
@@ -257,14 +69,11 @@ describe("session interceptor", () => {
     runInterceptor(interceptor, executionContext, doNothing, completeCallback, done);
   });
 
-  it("adds the session token to the context when creating a new session", (done) => {
-    expect.assertions(1);
-    const cookie = jest.fn();
+  it("creates a new user for the session if it doesn't exist yet", (done) => {
+    expect.assertions(2);
     const context: Context = {
       req: createMock<Request>(),
-      res: createMock<Response>({
-        cookie,
-      }),
+      res: null,
       sessionToken: null,
     };
     const executionContext = createMock<ExecutionContext>({
@@ -272,54 +81,20 @@ describe("session interceptor", () => {
       getArgs: jest.fn().mockReturnValue([null, context, null]),
     });
 
-    const interceptor = new SessionInterceptor(
-      createMock<JwtService>({
-        createSignedToken: jest.fn().mockResolvedValue("token"),
-        validateToken: jest.fn().mockResolvedValue(false),
-      }),
-      createMock<UserService>({
-        create: jest.fn().mockResolvedValue(UserFactory.build()),
-      }),
-      createMock<Logger>(),
-      createMock<ConfigService>(createConfigServiceMock()),
-    );
-
-    const completeCallback = (): void => {
-      expect(context.sessionToken).toBeTruthy();
-    };
-
-    runInterceptor(interceptor, executionContext, doNothing, completeCallback, done);
-  });
-
-  it("creates a new user for new sessions", (done) => {
-    expect.assertions(1);
-    const cookie = jest.fn();
-    const context: Context = {
-      req: createMock<Request>(),
-      res: createMock<Response>({
-        cookie,
-      }),
-      sessionToken: null,
-    };
-    const executionContext = createMock<ExecutionContext>({
-      getType: jest.fn().mockReturnValue("graphql"),
-      getArgs: jest.fn().mockReturnValue([null, context, null]),
-    });
+    const createIfNotExists = jest.fn().mockResolvedValue(UserFactory.build());
 
     const interceptor = new SessionInterceptor(
       createMock<JwtService>({
-        createSignedToken: jest.fn().mockResolvedValue("token"),
-        validateToken: jest.fn().mockResolvedValue(false),
+        decodeToken: jest.fn().mockReturnValue({ sub: "user-id" }),
       }),
-      createMock<UserService>({
-        create: jest.fn().mockResolvedValue(UserFactory.build()),
-      }),
+      createMock<UserService>({ createIfNotExists }),
       createMock<Logger>(),
       createMock<ConfigService>(createConfigServiceMock()),
     );
 
     const completeCallback = (): void => {
       expect(context.sessionToken?.userId).toBeTruthy();
+      expect(createIfNotExists).toHaveBeenCalledWith("user-id");
     };
 
     runInterceptor(interceptor, executionContext, doNothing, completeCallback, done);

--- a/tests/api/unit/authentication/store.service.spec.ts
+++ b/tests/api/unit/authentication/store.service.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { ConfigService } from "@nestjs/config";
 import { createConfigServiceMock } from "@tests/support/helpers";

--- a/tests/api/unit/authentication/strategies/twitter.strategy.spec.ts
+++ b/tests/api/unit/authentication/strategies/twitter.strategy.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";

--- a/tests/api/unit/mail/mail.service.spec.ts
+++ b/tests/api/unit/mail/mail.service.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";

--- a/tests/api/unit/submission/check-submission.service.spec.ts
+++ b/tests/api/unit/submission/check-submission.service.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock, PartialFuncReturn } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/axe-checks.spec.ts
+++ b/tests/api/unit/submission/checks/axe-checks.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { AXE_CHECKS_TO_CHECK_NAMES_MAP, buildCheckNames, buildCheckProviders } from "@/submission/checks/axe-checks";
 
 describe("axe checks", () => {

--- a/tests/api/unit/submission/checks/color-contrast-greater-than-or-equal.check.spec.ts
+++ b/tests/api/unit/submission/checks/color-contrast-greater-than-or-equal.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/document-language-is-specified.check.spec.ts
+++ b/tests/api/unit/submission/checks/document-language-is-specified.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/document-starts-with-html5-doctype.check.spec.ts
+++ b/tests/api/unit/submission/checks/document-starts-with-html5-doctype.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/element-contains-text.check.spec.ts
+++ b/tests/api/unit/submission/checks/element-contains-text.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/element-exists.check.spec.ts
+++ b/tests/api/unit/submission/checks/element-exists.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/element-has-css-property-value-greater-than.check.spec.ts
+++ b/tests/api/unit/submission/checks/element-has-css-property-value-greater-than.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/element-has-css-property-value.check.spec.ts
+++ b/tests/api/unit/submission/checks/element-has-css-property-value.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/element-has-minimum-dimension.spec.ts
+++ b/tests/api/unit/submission/checks/element-has-minimum-dimension.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/element-not-contains-text.check.spec.ts
+++ b/tests/api/unit/submission/checks/element-not-contains-text.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/element-not-exists.check.spec.ts
+++ b/tests/api/unit/submission/checks/element-not-exists.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/html-is-valid.check.spec.ts
+++ b/tests/api/unit/submission/checks/html-is-valid.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/submission/checks/margin-between-elements-greater-than-or-equal.check.spec.ts
+++ b/tests/api/unit/submission/checks/margin-between-elements-greater-than-or-equal.check.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock } from "@golevelup/ts-jest";
 import { Logger } from "@nestjs/common";
 import { createRule, createSubmission } from "@tests/support/helpers";

--- a/tests/api/unit/user/last-seen.interceptor.spec.ts
+++ b/tests/api/unit/user/last-seen.interceptor.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { createMock, DeepMocked } from "@golevelup/ts-jest";
 import { ExecutionContext } from "@nestjs/common";
 import { runInterceptor } from "@tests/support/helpers";

--- a/tests/api/unit/user/user.service.spec.ts
+++ b/tests/api/unit/user/user.service.spec.ts
@@ -9,6 +9,7 @@ import { ConfigService } from "@nestjs/config";
 import { CODE_LEVEL_SUBMISSION, CodeLevelSubmissionData, Factory, USER, UserData } from "@tests/support/factories/database";
 import { UserFactory } from "@tests/support/factories/models/user.factory";
 import { createConfigServiceMock, useDatabase } from "@tests/support/helpers";
+import crypto from "crypto";
 
 import { HashService } from "@/authentication/hash.service";
 import { ProviderInformation } from "@/authentication/interfaces/provider-information.interface";
@@ -40,6 +41,21 @@ describe("user service", () => {
     it("can create a user", async () => {
       const service = getUserService();
       expect(await service.create()).toHaveProperty("id", expect.any(String));
+    });
+  });
+
+  describe("createIfNotExists", () => {
+    it("creates a user if doesn't exist", async () => {
+      const id = crypto.randomUUID();
+      const service = getUserService();
+      expect(await service.createIfNotExists(id)).toHaveProperty("id", id);
+    });
+
+    it("returns the existing user if already exists", async () => {
+      const id = crypto.randomUUID();
+      const service = getUserService();
+      await service.create(id);
+      expect(await service.createIfNotExists(id)).toHaveProperty("id", id);
     });
   });
 

--- a/tests/middleware.spec.ts
+++ b/tests/middleware.spec.ts
@@ -1,19 +1,34 @@
-import { CurrentUserDocument } from "app/generated/graphql";
-import { createApolloClientRSC } from "app/lib/apollo-client/create-apollo-client-rsc";
+/**
+ * @jest-environment node
+ */
+
+import { JwtScope } from "app/api/authentication/enums/jwt-scope.enum";
 import middleware from "app/middleware";
+import crypto from "crypto";
+import * as jose from "jose";
 import { NextURL } from "next/dist/server/web/next-url";
 import { NextRequest } from "next/server";
-
-import { createTerminatingLink } from "./lib/apollo-client/helpers";
 
 jest.mock("app/lib/apollo-client/create-apollo-client-rsc", () => ({
   createApolloClientRSC: jest.fn(),
 }));
 
-function getRequest(url: string): NextRequest {
+Object.defineProperty(global, "self", {
+  value: {
+    crypto: crypto.webcrypto,
+  },
+});
+
+function getRequest(
+  url: string,
+  options: Partial<{
+    cookies: Map<string, { name: string; value: string }>;
+  }> = {},
+): NextRequest {
   return {
     nextUrl: { clone: () => new NextURL(url) },
     headers: { get: () => "a11yphant.com" },
+    cookies: options.cookies || new Map(),
   } as unknown as NextRequest;
 }
 
@@ -34,17 +49,91 @@ describe("middleware", () => {
     expect(res?.headers.get("location")).toEqual("http://a11yphant.com/challenges/headings/level/1");
   });
 
-  it("creates a user if no user cookie is set", async () => {
-    const client = { query: jest.fn(), link: createTerminatingLink(), setLink: jest.fn() };
-    (createApolloClientRSC as jest.Mock).mockReturnValue(client);
-    const req = {
-      nextUrl: { clone: () => new NextURL("http://a11yphant.com/page") },
-      cookies: { has: () => false },
-      headers: { toString: () => "", get: () => "a11yphant.com" },
-    } as unknown as NextRequest;
+  it("creates a new session if no cookie is present", async () => {
+    const req = getRequest("http://a11yphant.com");
+    const res = await middleware(req);
 
-    await middleware(req);
+    expect(res).toBeDefined();
+    expect(res.cookies.has("a11yphant_session")).toBeDefined();
+  });
 
-    expect(client.query).toHaveBeenCalledWith(expect.objectContaining({ query: CurrentUserDocument }));
+  it("the created session cookie has a sub set", async () => {
+    const req = getRequest("http://a11yphant.com");
+    const res = await middleware(req);
+
+    const cookie = res.cookies.get("a11yphant_session");
+    const payload = jose.decodeJwt(cookie.value);
+    expect(payload.sub).toBeDefined();
+  });
+
+  it("the created session cookie is signed with the secret and has a11yphant as an issuer", async () => {
+    const req = getRequest("http://a11yphant.com");
+    const res = await middleware(req);
+
+    const cookie = res.cookies.get("a11yphant_session");
+    await expect(jose.jwtVerify(cookie.value, Buffer.from(process.env.API_KEY), { issuer: "a11yphant" })).resolves.toBeTruthy();
+  });
+
+  it("the created session cookie has the session scope set", async () => {
+    const req = getRequest("http://a11yphant.com");
+    const res = await middleware(req);
+
+    const cookie = res.cookies.get("a11yphant_session");
+    const payload = jose.decodeJwt(cookie.value);
+    expect(payload.scope).toBe(JwtScope.SESSION);
+  });
+
+  it("extends the lifetime of the cookie if one is already present", async () => {
+    const secret = process.env.API_KEY;
+    const token = await new jose.SignJWT({ scope: JwtScope.SESSION })
+      .setProtectedHeader({
+        alg: "HS256",
+      })
+      .setIssuer("a11yphant")
+      .setSubject("user-id")
+      .setExpirationTime(`10 seconds from now`)
+      .sign(Buffer.from(secret));
+
+    const cookie = {
+      name: "a11yphant_session",
+      value: token,
+    };
+
+    const cookies = new Map();
+    cookies.set(cookie.name, cookie);
+    const req = getRequest("http://a11yphant.com", { cookies });
+    const res = await middleware(req);
+
+    const responseJwt = jose.decodeJwt(res.cookies.get("a11yphant_session").value);
+    const requestJwt = jose.decodeJwt(token);
+    expect(responseJwt.exp).not.toEqual(requestJwt.exp);
+  });
+
+  it("overwrites existing session cookies if they are invalid", async () => {
+    const cookies = new Map();
+    cookies.set("a11yphant_session", { name: "a11yphant_session", value: "invalid" });
+    const req = getRequest("http://a11yphant.com", { cookies });
+
+    const res = await middleware(req);
+
+    const cookie = res.cookies.get("a11yphant_session");
+    expect(cookie.value).not.toBe("invalid");
   });
 });
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico,
+     * - sitemap.xml,
+     * - robots.txt (metadata files),
+     * - fonts
+     * - images
+     * - videos
+     */
+    "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|fonts/|images/|videos/).*)",
+  ],
+};


### PR DESCRIPTION
# Description

This MR moves managing the session cookie to the Nextjs middleware instead of handling the token in the Nestjs interceptor for the GraphQL API. This allows the middleware to return a response before the API function and also the database spun up. This allows us to start streaming responses right away, which greatly reduces the perceived cold start time for the application.


Additional Info:
- Using the `jose` library instead of `jsonwebtokens` was required for runtime compatibility with Nextjs middlewares (no node APIs are available there).
- Using the `jose` library in the test support files caused a bunch of transpilation errors in Jest which were caused by the `jsdom` runtime. I switched these manually to the `node` environment to avoid the errors. As these are API tests that's the more appropriate runtime anyways (this caused quite a few of the changed lines here).

## Definition of Done

### General

- [ ] Code Review
- [x] Test Coverage is equal or higher
- [x] Update ticket on the TODO board
- [x] (if .env file changes) Notify other team members

### API

- [x] (if new resolver) Add resolver to generate-schema.ts
- [x] Create description for endpoints und models

### Site

- [x] Works in Firefox, Chrome and Safari
- [x] No W3C Errors (Wave Check)
- [x] Focus, Hover & Active Styles are present
- [x] Correct Tab Order
- [x] All relevant elements are focusable
- [x] Screen reader only reads relevant infos (no SVGs, ...)